### PR TITLE
Fix npm start workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+### Production build
+
+To test the production build locally, simply run:
+
+```bash
+npm start
+```
+
+The `start` script automatically builds the project and starts Next.js in production mode.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "prestart": "next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
## Summary
- add automatic build step for `npm start`
- document how to run the production build

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438fd4d19c8322906b7c84ca7c6a94