### PR TITLE
Fix npm start workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) together with the [`geist`](https://www.npmjs.com/package/geist) package to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+### Production build
+
+To test the production build locally, simply run:
+
+```bash
+npm start
+```
+
+The `start` script automatically builds the project and starts Next.js in production mode.
 
 ## Learn More
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { GeistSans, GeistMono } from "geist/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
+const geistSans = GeistSans({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
+const geistMono = GeistMono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
+    "prestart": "next build",
     "start": "next start",
     "lint": "next lint"
   },
@@ -13,6 +14,7 @@
     "contentlayer": "^0.3.4",
     "next": "14.2.3",
     "next-contentlayer": "^0.3.4",
+    "geist": "^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary
- add automatic build step for `npm start`
- document how to run the production build
- fix font imports for production build

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438fd4d19c8322906b7c84ca7c6a94